### PR TITLE
Fix debian configuration

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class postgresql::params {
   }
 
   $configfilehba = $operatingsystem ? {
-    ubuntu  => '/etc/postgresql/8.4/main/pg_hba.conf',
+    /(?i:Debian|Ubuntu|Mint)/ => '/etc/postgresql/8.4/main/pg_hba.conf',
     default => '/var/lib/pgsql/data/pg_hba.conf',
   }
 


### PR DESCRIPTION
I've found some mistake when using puppet-postgresql with debian.

If you're using debian, default init script is /etc/init.d/postgresql not /etc/init.d/postgresql-8.4.

If you want proceed hba modification, debian is not correctly detected.

This PR correct this.

Thank you for all your work.

Romain
