### PR TITLE
FIX: Fix installation order for hba file

### DIFF
--- a/manifests/hbaconcat.pp
+++ b/manifests/hbaconcat.pp
@@ -1,11 +1,13 @@
 class postgresql::hbaconcat {
 
   include concat::setup
+  include postgresql
 
   concat { "${postgresql::configfilehba}":
-    mode  => '0600',
-    owner => $postgresql::config_file_owner,
-    group => $postgresql::config_file_group,
+    mode    => '0600',
+    owner   => $postgresql::config_file_owner,
+    group   => $postgresql::config_file_group,
+    require => Package['postgresql'],
   }
 
   # The File Header. With Puppet comment

--- a/spec/defines/postgresql_hba_spec.rb
+++ b/spec/defines/postgresql_hba_spec.rb
@@ -1,0 +1,18 @@
+require "#{File.join(File.dirname(__FILE__),'..','spec_helper.rb')}"
+
+describe 'postgresql::hba', :type => :define do
+
+  let(:title) { 'postgresql::hba' }
+  let(:node) { 'rspec.example42.com' }
+  let(:facts) { { :arch => 'i386', :operatingsystem => 'Debian' } }
+  let(:params) { {
+    :type     => 'local',
+    :database => 'all',
+    :user     => 'all',
+    :method   => 'password'
+  } }
+
+  describe 'Test postgresql::hba require postgresql to be install' do
+    it { should contain_concat('/etc/postgresql/8.4/main/pg_hba.conf').with_require(/Package/) }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # Based on https://github.com/puppetlabs/puppetlabs-ntp/blob/master/spec/spec_helper.rb
-# Thanks to Ken Barber for advice about http://projects.puppetlabs.com/issues/11191  
+# Thanks to Ken Barber for advice about http://projects.puppetlabs.com/issues/11191
 require 'puppet'
 require 'rspec-puppet'
 require 'tmpdir'
@@ -18,7 +18,9 @@ RSpec.configure do |c|
   c.filter_run_excluding :broken => true
 
   c.after :each do
-    FileUtils.remove_entry_secure(@puppetdir)
+    if FileTest.exists?("#{@puppetdir}")
+      FileUtils.remove_entry_secure(@puppetdir)
+    end
   end
 
   c.module_path = File.join(File.dirname(__FILE__), '../../')


### PR DESCRIPTION
In order to add data into hba file you have to install postgresql first.

I think this PR will correct issue #2.
