### PR TITLE
[PROTOTYPE] wheezy will have only postgres-9.1

### DIFF
--- a/templates/spec.erb
+++ b/templates/spec.erb
@@ -4,5 +4,5 @@
 <%= scope.to_hash.reject { |k,v| !( k.is_a?(String) && v.is_a?(String) ) }.to_yaml %>
 
 # Custom Options
-<%= options['opt_a'] %>
-<%= options['opt_b'] %>
+<%= @options['opt_a'] %>
+<%= @options['opt_b'] %>


### PR DESCRIPTION
This probably shouldn't be merged as-is. I just wanted to bring up this issue with code attached.

I guess that there'll need to be a new $postgresql::version param and associated logic in ::params to guess a default?
