### PR TITLE
ENH: add locale, encoding, and template options to dbcreate

### DIFF
--- a/manifests/dbcreate.pp
+++ b/manifests/dbcreate.pp
@@ -2,18 +2,21 @@
 # Requires a db name ($name) and a role. To be adapted for specific cases
 #
 define postgresql::dbcreate (
-  $role ,
+  $role,
+  $encoding     = 'SQL_ASCII',
+  $locale       = 'C',
+  $template     = 'template1',
   $password     = '',
   $conntype     = 'host',
   $address      = '127.0.0.1/32',
-  $auth_method  = 'md5' ,
+  $auth_method  = 'md5',
   $auth_options = '' ) {
 
   exec { "role_${name}":
     user    => $postgresql::process_user,
     path    => '/usr/bin:/bin:/usr/sbin:/sbin',
-    unless  => "echo \\\\dg | psql | grep ${name} 2>/dev/null",
-    command => "echo \"create role ${name} nosuperuser nocreatedb nocreaterole noinherit nologin ; alter role ${role} nosuperuser nocreatedb nocreaterole noinherit login encrypted password '${password}'; grant ${name} to ${role}; create database ${name} with owner=${role};\" | /usr/bin/psql",
+    unless  => "echo \\\\dg | psql | grep ${role} 2>/dev/null",
+    command => "echo \"create role ${role} nosuperuser nocreatedb nocreaterole noinherit nologin ; alter role ${role} nosuperuser nocreatedb nocreaterole noinherit login encrypted password '${password}'; grant ${name} to ${role}; create database ${name} with OWNER=${role} TEMPLATE=${template} ENCODING='${encoding}' LC_COLLATE='${locale}' LC_CTYPE='${locale}';\" | /usr/bin/psql",
   }
 
   postgresql::hba { "hba_${name}":


### PR DESCRIPTION
a) fix bug in role creation in dbcreate
b) allow setting of locale, template, encoding in dbcreate
