### PR TITLE
Correct postgresql version for Debian based distros

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -392,7 +392,21 @@ class postgresql (
     ''      => $postgresql::bool_use_postgresql_repo ? {
       true      => '9.2',
       false     => $::operatingsystem ? {
-        /(?i:Debian|Ubuntu|Mint)/       => '8.4',
+        'Debian'                        => $::lsbmajdistrelease ? {
+		7       => '9.1',
+		default => '8.4',
+	},
+	'Ubuntu'                        => $::lsbmajdistrelease ? {
+		12      => '9.1',
+		13      => '9.1',
+		default => '8.4',
+	},
+	'Mint'                          => $::lsbmajdistrelase ? {
+		13      => '9.1',
+		14      => '9.1',
+		15      => '9.1',
+		default => '8.4',
+	},
         /(?i:RedHat|Centos|Scientific)/ => '',
         default                         => '8.4',
       },


### PR DESCRIPTION
Debian should be correct and I think Ubuntu is
as well. Not as sure about Mint since I'm not
familiar with their repo system.
