### PR TITLE
Support fix in facter 2.2 to lsbmajdistrelease

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -399,8 +399,8 @@ class postgresql (
           default => '8.4',
         },
         'Ubuntu'                        => $::lsbmajdistrelease ? {
-          12      => '9.1',
-          13      => '9.1',
+          /^12/   => '9.1',
+          /^13/   => '9.1',
           default => '8.4',
         },
         'Mint'                          => $::lsbmajdistrelase ? {


### PR DESCRIPTION
Facter 2.2 fixed the meaning of lsbmajdistrelease under Ubuntu
(so that e.g. Ubuntu 14.04.1 has lsbmajdistrelease = 14.04 rather
than 14).

To accomodate this fix, this commit changes the version check
to use a regex.
