### PR TITLE
Fixed the encoding quotes to single quotes since it is a string constant

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -39,7 +39,7 @@ define postgresql::db (
   if $encoding == undef {
     $manage_query_encoding = ""
   } else {
-    $manage_query_encoding = " ENCODING \\\"${encoding}\\\""
+    $manage_query_encoding = " ENCODING '${encoding}'"
   }
 
   $manage_query_end = ";"


### PR DESCRIPTION
The `ENCODING` value should be a string not a system identifier so it should be single quoted (for instance in `manifests/dbcreate.pp` it is ok)
